### PR TITLE
Rework plugin for ingestion using significantly less resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "description": "Export PostHog events into Snowflake",
     "devDependencies": {
         "@posthog/plugin-contrib": "^0.0.5",
-        "@posthog/plugin-scaffold": "^0.10.0",
+        "@posthog/plugin-scaffold": "^0.11.0",
         "@types/generic-pool": "^3.1.9",
         "@types/snowflake-sdk": "^1.5.1",
         "generic-pool": "^3.7.1",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,14 @@
 {
     "name": "@posthog/snowflake-export-plugin",
     "private": true,
-    "version": "0.0.1",
-    "description": "Export PostHog events into SnowFlake",
+    "version": "0.1.0",
+    "description": "Export PostHog events into Snowflake",
     "devDependencies": {
+        "@posthog/plugin-contrib": "^0.0.5",
+        "@posthog/plugin-scaffold": "^0.10.0",
         "@types/generic-pool": "^3.1.9",
-        "@types/snowflake-sdk": "^1.5.1"
-    },
-    "dependencies": {
-        "@posthog/plugin-contrib": "^0.0.3",
-        "@posthog/plugin-scaffold": "^0.5.0",
-        "generic-pool": "^3.7.8",
+        "@types/snowflake-sdk": "^1.5.1",
+        "generic-pool": "^3.7.1",
         "snowflake-sdk": "^1.6.0"
     }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,9 +1,9 @@
 {
-    "name": "SnowFlake Export Plugin",
+    "name": "Snowflake Export Plugin",
     "url": "https://github.com/posthog/snowflake-export-plugin",
-    "description": "Export PostHog events into SnowFlake",
+    "description": "Export PostHog events into Snowflake",
     "main": "index.ts",
-    "posthogVersion": ">= 1.24.0",
+    "posthogVersion": ">= 1.26.0",
     "config": [
         {
             "key": "account",

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
     "url": "https://github.com/posthog/snowflake-export-plugin",
     "description": "Export PostHog events into Snowflake",
     "main": "index.ts",
-    "posthogVersion": ">= 1.26.0",
+    "posthogVersion": ">=1.25.0",
     "config": [
         {
             "key": "account",
@@ -46,19 +46,18 @@
             "hint": "Will be created if doesn't already exist."
         },
         {
+            "key": "stage",
+            "name": "DB Stage",
+            "type": "string",
+            "required": true,
+            "hint": "Will be created if doesn't already exist."
+        },
+        {
             "key": "eventsToIgnore",
             "name": "Events to ignore",
             "type": "string",
             "default": "$snapshot, $feature_flag_called",
             "hint": "Comma separated list of events to ignore"
         },
-        {
-            "key": "mergeFrequency",
-            "name": "Table Merge Frequency",
-            "type": "choice",
-            "choices": ["hour", "minute"],
-            "default": "hour",
-            "hint": "How often do we merge the temporary tables with the main export table. Once per hour (10 min past the hour) or once per minute (last 2 minutes excluded)"
-        }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,27 +11,15 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@maxmind/geoip2-node@^2.3.1":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@maxmind/geoip2-node/-/geoip2-node-2.3.2.tgz#a0aaf8452693491e815021fe16e692959490ba6d"
-  integrity sha512-a1TSZt3uWe7yrgE2WMdTItK6XuG2Aj125cAXA+JuT2nomv3oqIK8XXg9iJVpzNXAYRV72XO0+zY+3HluOGgF3w==
-  dependencies:
-    camelcase-keys "^6.0.1"
-    ip6addr "^0.2.3"
-    lodash.set "^4.3.2"
-    maxmind "^4.2.0"
+"@posthog/plugin-contrib@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-contrib/-/plugin-contrib-0.0.5.tgz#6c55f39c39dd9dd8af558888558a69bc3fe19aff"
+  integrity sha512-ic2JsfFUdLGF+fGYJPatWEB6gEFNoD89qz92FN1RE2QfLpr6YdyPNuMowzahya3hfC/jaLZ8QdPG/j5pSOgT7A==
 
-"@posthog/plugin-contrib@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-contrib/-/plugin-contrib-0.0.3.tgz#d0772c6dd9ec9944ebee9dc475e1e781256b0b5f"
-  integrity sha512-0HrE8AuPv3OLZA93RrJDbljn9u5D/wmiIkBCeckU3LL67LNozDIJgKsY4Td91zgc+b4Rlx/X0MJNp2l6BHbQqg==
-
-"@posthog/plugin-scaffold@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.5.0.tgz#0d46d0f39700ebf3cf613ba80a2c9a4dc6d13805"
-  integrity sha512-gE12hy/gYdMOYLP/PhbC2XfqvCeoXrdkFeR9HFfSK31RWU+aW+JMK7pi+CATatXfNpMCvjGxIYJk3QBPwm0WDA==
-  dependencies:
-    "@maxmind/geoip2-node" "^2.3.1"
+"@posthog/plugin-scaffold@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.10.0.tgz#e80f57c5d3833753632607bed3ca71ebf272b12b"
+  integrity sha512-c8lNzQTBMJ0X3SCjcaD+mXZIx2thc+ptf8G4gbfT9YBFFD6TMaxs+/APMUab2aRJRbVwOsCGj9poxwuF4wxPpA==
 
 "@types/generic-pool@^3.1.9":
   version "3.1.9"
@@ -199,20 +187,6 @@ buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
   integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
-
-camelcase-keys@^6.0.1:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
-  integrity sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==
-  dependencies:
-    camelcase "^5.3.1"
-    map-obj "^4.0.0"
-    quick-lru "^4.0.1"
-
-camelcase@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
-  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -387,7 +361,7 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-generic-pool@^3.7.8:
+generic-pool@^3.7.1:
   version "3.7.8"
   resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.7.8.tgz#202087bf5ec5e0b3bae39842a0ef98bcd4c1e450"
   integrity sha512-Pz93INFSbhjEROVbM91rurD05G+Kx8833rG+lVU57mznEBpzkc1f5/g+d511a1Yf8dbAEsm7DDA3QLytMFbiGA==
@@ -438,14 +412,6 @@ inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-ip6addr@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/ip6addr/-/ip6addr-0.2.3.tgz#660df0d27092434f0aadee025aba8337c6d7d4d4"
-  integrity sha512-qA9DXRAUW+lT47/i/4+Q3GHPwZjGt/atby1FH/THN6GVATA6+Pjp2nztH7k6iKeil7hzYnBwfSsxjthlJ8lJKw==
-  dependencies:
-    assert-plus "^1.0.0"
-    jsprim "^1.4.0"
 
 is-arrayish@^0.3.1:
   version "0.3.2"
@@ -520,7 +486,7 @@ jsonwebtoken@^8.5.1:
     ms "^2.1.1"
     semver "^5.6.0"
 
-jsprim@^1.2.2, jsprim@^1.4.0:
+jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
   integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
@@ -587,11 +553,6 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
-
 lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
@@ -607,19 +568,6 @@ logform@^2.2.0:
     fecha "^4.2.0"
     ms "^2.1.1"
     triple-beam "^1.3.0"
-
-map-obj@^4.0.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.2.1.tgz#e4ea399dbc979ae735c83c863dd31bdf364277b7"
-  integrity sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==
-
-maxmind@^4.2.0:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/maxmind/-/maxmind-4.3.1.tgz#b20103f19e9fc12e4d1618814380d89a00f65770"
-  integrity sha512-0CxAgwWIwQy4zF1/qCMOeUPleMTYgfnsuIsZ4Otzx6hzON4PCqivPiH6Kz7iWrC++KOGCbSB3nxkJMvDEdWt6g==
-  dependencies:
-    mmdb-lib "1.2.0"
-    tiny-lru "7.0.6"
 
 mime-db@1.46.0:
   version "1.46.0"
@@ -642,11 +590,6 @@ mkdirp@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
-mmdb-lib@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mmdb-lib/-/mmdb-lib-1.2.0.tgz#0ecd93f4942f65a2d09be0502fa9126939606727"
-  integrity sha512-3XYebkStxqCgWJjsmT9FCaE19Yi4Tvs2SBPKhUks3rJJh52oF1AKAd9kei+LTutud3a6RCZ0o2Um96Fn7o3zVA==
 
 mock-require@^3.0.3:
   version "3.0.3"
@@ -735,11 +678,6 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-
-quick-lru@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
-  integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
 readable-stream@^2.3.7:
   version "2.3.7"
@@ -840,7 +778,7 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
-snowflake-sdk@^1.6.1:
+snowflake-sdk@^1.6.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/snowflake-sdk/-/snowflake-sdk-1.6.1.tgz#371a19bc04922c437ef72b62f1a59b5c5999d577"
   integrity sha512-w56tIP8mXyD2pXFzeV78sQjiBZBdPshKII2K/9E6Wo++eM+JMcY2qszq3jIjyIsXSWKDcUlKUR2ENcG7WDWeUQ==
@@ -907,11 +845,6 @@ text-hex@1.0.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
   integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
-
-tiny-lru@7.0.6:
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/tiny-lru/-/tiny-lru-7.0.6.tgz#b0c3cdede1e5882aa2d1ae21cb2ceccf2a331f24"
-  integrity sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==
 
 tough-cookie@~2.5.0:
   version "2.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,10 +16,10 @@
   resolved "https://registry.yarnpkg.com/@posthog/plugin-contrib/-/plugin-contrib-0.0.5.tgz#6c55f39c39dd9dd8af558888558a69bc3fe19aff"
   integrity sha512-ic2JsfFUdLGF+fGYJPatWEB6gEFNoD89qz92FN1RE2QfLpr6YdyPNuMowzahya3hfC/jaLZ8QdPG/j5pSOgT7A==
 
-"@posthog/plugin-scaffold@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.10.0.tgz#e80f57c5d3833753632607bed3ca71ebf272b12b"
-  integrity sha512-c8lNzQTBMJ0X3SCjcaD+mXZIx2thc+ptf8G4gbfT9YBFFD6TMaxs+/APMUab2aRJRbVwOsCGj9poxwuF4wxPpA==
+"@posthog/plugin-scaffold@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.11.0.tgz#2c94621a98ce5162d5576737e3caf66b1c94941f"
+  integrity sha512-ZqI9yBe9hSswf6lDf2Ydl/hRk0WFd4ARluu3pOwkkPOwCfnPhkbPR6729inCPvuw2yoKV/IWOOg/yyd70Nh3AQ==
 
 "@types/generic-pool@^3.1.9":
   version "3.1.9"


### PR DESCRIPTION
This reworks the plugin to a large degree, to make it much more practical cost-wise to its users.

For now, the current approach with buffer tables created, merged, then deleted continuously has been exporting events to Snowflake mostly OK and generally doing _a_ job… But that job has proven to be really not optimal, incurring high costs for users.
That is due to us causing Snowflake virtual warehouses (basically compute instances spun up for any tasks on tables, e.g. analysis, ingestion) to run a lot of the time, with no time to wind down. And Snowflake bills based on how long a virtual warehouse is on.
We can remediate this by completely avoiding `INSERT` – with a continuous load like the one presented by the plugin server, it's a total waste of compute, since the Snowflake DB is optimized for loading huge chunks of data at once, not tiny ones all the time.

The _optimal_ way is by first exporting the events continuously to a Snowflake _stage_ – a stage is basically an object storage bucket containing files to be ingested _at some point_.

We have two (**practical**) choices regarding what type of stage we can use:
1. Snowflake (internal),
2. Amazon S3 (external).

The tradeoffs are that:
1. With internal Snowflake, well… would love to use it, but it's not supported by all libraries, and the JS one happens to be one of them! There's a [PR to the library out](https://github.com/snowflakedb/snowflake-connector-nodejs/pull/169) (not merged yet), which at least adds support for the appropriate command (`PUT`), but it only supports uploading to S3 now, so the Snowflake internal stage is still to be reverse engineered from the Python library.
  But also the internal stage requires a very specific way of uploading data: it has to be an actual file on disk. Which is bad for us, because we really don't want plugins to access the real filesystem. This could probably be worked around by making the library actually use some other provided data (not from disk, all a bit hacky) for upload.
2. With external Amazon S3, users of the plugin would have to allow the plugin appropriate access to an S3 bucket, just like the S3 export plugin – increasing the amount of configuration needed. However this would be very simple to implement – we already support the AWS SDK in plugins, and uploading a file to S3 is trivial.

There are also two choices regarding what method of ingestion in the the actual table we can use:
1. `COPY` command every hour or so,
2. Snowpipe.

In here:
1. `COPY` would be very simple and good compute-wise, just that there would be a delay in getting the data.
2. Snowpipe would give near real-time ingestion, at a lot more implementation complexity – it's another feature not supported by the JS SDK. It's not a complicated HTTP API request though, so that's good… EXCEPT Snowpipe can only be authenticated using a key pair, which A. is more work to set up for the user B. we had to _remove_ support for key pair auth, because an invalid file can crash the plugin server via OpenSSL. So that seems like a hard path.

Due to the above I'll go for S3 upload (meaning: S3 credentials required) + periodic `COPY` from that Snowflake stage.