### PR TITLE
Add support for S3 Stage

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -179,7 +179,7 @@ class Snowflake {
                 throw new Error('S3 connector not initialized correctly.')
             }
             await this.execute({
-                sqlText: `CREATE OR REPLACE STAGE "${this.database}"."${this.dbschema}"."${this.stage}"
+                sqlText: `CREATE STAGE IF NOT EXISTS "${this.database}"."${this.dbschema}"."${this.stage}"
             URL='s3://${this.s3Options.bucketName}'
             FILE_FORMAT = ( TYPE = 'CSV' SKIP_HEADER = 1 )
             CREDENTIALS=(aws_key_id='${this.s3Options.awsAccessKeyId}' aws_secret_key='${this.s3Options.awsSecretAccessKey}')
@@ -295,7 +295,7 @@ class Snowflake {
             }
        }
         
-       const fileName = `${global.batchId}-snowflake-export-${day}/${dayTime}-${suffix}.csv`
+       const fileName = `${global.batchId}-snowflake-export-${day}-${dayTime}-${suffix}.csv`
 
         const params = {
             Bucket: config.s3BucketName,
@@ -393,7 +393,7 @@ const snowflakePlugin: Plugin<SnowflakePluginInput> = {
             lastRun &&
             timeNow - Number(lastRun) < ONE_HOUR 
         ) {
-            return
+            //return
         }
         await cache.set('lastRun', timeNow)
         if (global.useS3) {

--- a/index.ts
+++ b/index.ts
@@ -85,10 +85,10 @@ function transformEventToRow(fullEvent: PluginEvent): TableRow {
         site_url,
         timestamp,
         uuid: uuid!,
-        properties: JSON.stringify(ingestedProperties || ({} as Record<any, any>)),
-        elements: JSON.stringify(elements || ([] as Record<any, any>)),
-        people_set: JSON.stringify($set || ({} as Record<any, any>)),
-        people_set_once: JSON.stringify($set_once || ({} as Record<any, any>)),
+        properties: JSON.stringify(ingestedProperties || {}),
+        elements: JSON.stringify(elements || []),
+        people_set: JSON.stringify($set || {}),
+        people_set_once: JSON.stringify($set_once || {}),
     }
 }
 interface SnowflakeOptions {

--- a/index.ts
+++ b/index.ts
@@ -126,10 +126,10 @@ class Snowflake {
     constructor({ account, username, password, database, dbschema, table, stage, specifiedRole }: SnowflakeOptions) {
         this.pool = this.createConnectionPool(account, username, password, specifiedRole)
         this.s3connector = null
-        this.database = database
-        this.dbschema = dbschema
-        this.table = table
-        this.stage = stage
+        this.database = database.toUpperCase()
+        this.dbschema = dbschema.toUpperCase()
+        this.table = table.toUpperCase()
+        this.stage = stage.toUpperCase()
         this.s3Options = null
     }
 

--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,18 @@
 import * as snowflake from 'snowflake-sdk'
 import { createPool, Pool } from 'generic-pool'
 import { PluginEvent, Plugin, RetryError } from '@posthog/plugin-scaffold'
-import crypto from 'crypto'
+/* import crypto from 'crypto'
+import fetch from 'node-fetch' */
+import { randomBytes } from 'crypto'
+import { ManagedUpload } from 'aws-sdk/clients/s3'
+import { S3 } from 'aws-sdk'
 
 interface SnowflakePluginInput {
     global: {
         snowflake: Snowflake
         eventsToIgnore: Set<string>
+        useS3: boolean
+        batchId: number
     }
     config: {
         account: string
@@ -17,6 +23,11 @@ interface SnowflakePluginInput {
         table: string
         stage: string
         eventsToIgnore: string
+        s3BucketName: string
+        awsAccessKeyId: string
+        awsSecretAccessKey: string
+        awsRegion: string
+        stageToUse: 'S3' | 'Google Cloud Storage'
     }
 }
 
@@ -25,8 +36,8 @@ interface TableRow {
     event: string
     properties: string // Record<string, any>
     elements: string // Record<string, any>
-    set: string // Record<string, any>
-    set_once: string // Record<string, any>
+    people_set: string // Record<string, any>
+    people_set_once: string // Record<string, any>
     distinct_id: string
     team_id: number
     ip: string
@@ -37,10 +48,10 @@ interface TableRow {
 const TABLE_SCHEMA = [
     { name: 'uuid', type: 'STRING' },
     { name: 'event', type: 'STRING' },
-    { name: 'properties', type: 'VARIANT' },
-    { name: 'elements', type: 'VARIANT' },
-    { name: 'set', type: 'VARIANT' },
-    { name: 'set_once', type: 'VARIANT' },
+    { name: 'properties', type: 'OBJECT' },
+    { name: 'elements', type: 'OBJECT' },
+    { name: 'people_set', type: 'OBJECT' },
+    { name: 'people_set_once', type: 'OBJECT' },
     { name: 'distinct_id', type: 'STRING' },
     { name: 'team_id', type: 'INTEGER' },
     { name: 'ip', type: 'STRING' },
@@ -49,20 +60,9 @@ const TABLE_SCHEMA = [
 ]
 
 function transformEventToRow(fullEvent: PluginEvent): TableRow {
-    const {
-        event,
-        properties,
-        $set,
-        $set_once,
-        distinct_id,
-        team_id,
-        site_url,
-        now,
-        sent_at,
-        uuid,
-        ...rest
-    } = fullEvent
-    const ip = properties?.['$ip'] || event.ip
+    const { event, properties, $set, $set_once, distinct_id, team_id, site_url, now, sent_at, uuid, ...rest } =
+        fullEvent
+    const ip = properties?.['$ip'] || fullEvent.ip
     const timestamp = fullEvent.timestamp || properties?.timestamp || now || sent_at
     let ingestedProperties = properties
     let elements = []
@@ -73,14 +73,14 @@ function transformEventToRow(fullEvent: PluginEvent): TableRow {
         ingestedProperties = props
         elements = $elements
     }
-    
+
     return {
         uuid: uuid!,
         event,
         properties: JSON.stringify(ingestedProperties || {}),
         elements: JSON.stringify(elements || []),
-        set: JSON.stringify($set || {}),
-        set_once: JSON.stringify($set_once || {}),
+        people_set: JSON.stringify($set || {}),
+        people_set_once: JSON.stringify($set_once || {}),
         distinct_id,
         team_id,
         ip,
@@ -89,11 +89,47 @@ function transformEventToRow(fullEvent: PluginEvent): TableRow {
     }
 }
 
+interface SnowflakeOptions {
+    account: string
+    username: string
+    password: string
+    database: string
+    dbschema: string
+    table: string
+    stage: string
+}
+
+interface S3AuthOptions {
+    awsAccessKeyId: string
+    awsSecretAccessKey: string
+    bucketName: string
+}
 class Snowflake {
     private pool: Pool<snowflake.Connection>
+    private s3connector: S3 | null
+    database: string
+    dbschema: string
+    table: string
+    stage: string
+    s3Options: S3AuthOptions | null
 
-    constructor(account: string, username: string, password: string) {
+
+    constructor({
+        account,
+        username,
+        password,
+        database,
+        dbschema,
+        table,
+        stage,
+    }: SnowflakeOptions) {
         this.pool = this.createConnectionPool(account, username, password)
+        this.s3connector = null
+        this.database = database
+        this.dbschema= dbschema
+        this.table = table
+        this.stage = stage
+        this.s3Options = null
     }
 
     public async clear(): Promise<void> {
@@ -101,54 +137,55 @@ class Snowflake {
         await this.pool.clear()
     }
 
+    public createS3Connector(awsAccessKeyId: string, awsSecretAccessKey: string, awsRegion: string, bucketName: string) {
+        if (!awsAccessKeyId || !awsSecretAccessKey || !awsRegion || !bucketName) {
+            throw new Error(
+                'You must provide an AWS Access Key ID, Secret Access Key, bucket name, and bucket region to use the S3 stage.'
+            )
+        }
+        this.s3connector = new S3({
+            accessKeyId: awsAccessKeyId,
+            secretAccessKey: awsSecretAccessKey,
+            region: awsRegion,
+        })
+        this.s3Options = {
+            awsAccessKeyId,
+            awsSecretAccessKey,
+            bucketName
+        }
+    }
+
     public async createTableIfNotExists(
-        database: string,
-        dbschema: string,
-        table: string,
-        columns: string
+    columns: string
     ): Promise<void> {
         await this.execute({
-            sqlText: `CREATE TABLE IF NOT EXISTS "${database}"."${dbschema}"."${table}" (${columns})`,
+            sqlText: `CREATE TABLE IF NOT EXISTS "${this.database}"."${this.dbschema}"."${this.table}" (${columns})`,
         })
     }
-    
-    public async dropTableIfExists(
-        database: string,
-        dbschema: string,
-        table: string
-    ): Promise<void> {
+
+    public async dropTableIfExists(): Promise<void> {
         await this.execute({
-            sqlText: `DROP TABLE IF EXISTS "${database}"."${dbschema}"."${table}"`,
+            sqlText: `DROP TABLE IF EXISTS "${this.database}"."${this.dbschema}"."${this.table}"`,
         })
     }
-    
-    public async createPipeIfNotExists(
-        database: string,
-        dbschema: string,
-        table: string,
-        pipe: string,
-        stage: string
-    ): Promise<void> {
-        await this.execute({
-            sqlText: `CREATE PIPE "${database}"."${dbschema}"."${pipe}" IF NOT EXISTS
-            AS COPY INTO "${database}"."${dbschema}"."${table}" FROM "${database}"."${dbschema}"."${stage}"`
-        })
-    }
-    
-    public async createStageIfNotExists(
-        database: string,
-        dbschema: string, stage: string): Promise<void> {
+
+    public async createStageIfNotExists(useS3 = true): Promise<void> {
+        if (useS3) {
+            if (!this.s3Options) {
+                throw new Error('S3 connector not initialized correctly.')
+            }
             await this.execute({
-                sqlText:
-        `CREATE STAGE IF NOT EXISTS "${database}"."${dbschema}"."${stage}"
-        FILE_FORMAT = ( TYPE = 'JSON' STRIP_OUTER_ARRAY = TRUE )
-        COMMENT = 'Stage used by the PostHog Snowflake export plugin'` })
+                sqlText: `CREATE STAGE IF NOT EXISTS "${this.database}"."${this.dbschema}"."${this.stage}"
+            URL='s3://${this.s3Options.bucketName}'
+            FILE_FORMAT = ( TYPE = 'CSV' SKIP_HEADER = 1 )
+            CREDENTIALS=(aws_key_id='${this.s3Options.awsAccessKeyId}' aws_secret_key='${this.s3Options.awsSecretAccessKey}')
+            ENCRYPTION=(type='AWS_SSE_KMS' kms_key_id = 'aws/key');
+            COMMENT = 'S3 Stage used by the PostHog Snowflake export plugin'`,
+            })
+        }
     }
-    
-    public async execute({ sqlText, binds }: {
-        sqlText: string
-        binds?: snowflake.Binds
-    }): Promise<any[] | undefined> {
+
+    public async execute({ sqlText, binds }: { sqlText: string; binds?: snowflake.Binds }): Promise<any[] | undefined> {
         const snowflake = await this.pool.acquire()
         try {
             return await new Promise((resolve, reject) =>
@@ -179,7 +216,7 @@ class Snowflake {
                         username,
                         password,
                     })
-    
+
                     await new Promise<string>((resolve, reject) =>
                         connection.connect((err, conn) => {
                             if (err) {
@@ -190,7 +227,7 @@ class Snowflake {
                             }
                         })
                     )
-    
+
                     return connection
                 },
                 destroy: async (connection) => {
@@ -214,69 +251,151 @@ class Snowflake {
             }
         )
     }
+
+    async uploadToS3(events: TableRow[], meta: SnowflakePluginInput) {
+        if (!this.s3connector) {
+            throw new Error('S3 connector not setup correctly!')
+        }
+        const { global, config } = meta
+
+        const date = new Date().toISOString()
+        const [day, time] = date.split('T')
+        const dayTime = `${day.split('-').join('')}-${time.split(':').join('')}`
+        const suffix = randomBytes(8).toString('hex')
+
+
+        let csvString = ''
+
+       // events.map((event) => JSON.stringify(event)).join('\n')
+
+       for (let i = 0; i < events.length; ++i) {
+            const {
+                uuid,
+                event,
+                properties,
+                elements,
+                people_set,
+                people_set_once,
+                distinct_id,
+                team_id,
+                ip,
+                site_url,
+                timestamp,
+            } = events[i]
+
+            // order is important
+            csvString += `${uuid},${event},${properties},${elements},${people_set},${people_set_once},${distinct_id},${team_id},${ip},${site_url},${timestamp}`
+
+            if (i !== (events.length - 1)) {
+                csvString += '\n'
+            }
+       }
+        
+       const fileName = `${global.batchId}-snowflake-export-${day}/${dayTime}-${suffix}.csv`
+
+        const params = {
+            Bucket: config.s3BucketName,
+            Key: fileName,
+            Body: Buffer.from(csvString, 'utf8'),
+        }
+
+        console.log(`Flushing ${events.length} events!`)
+        await new Promise<void>((resolve) => {
+            this.s3connector!.upload(params, async (err: Error, _: ManagedUpload.SendData) => {
+                if (err) {
+                    console.error(`Error uploading to S3: ${err.message}`)
+                    throw new RetryError()
+                }
+                console.log(
+                    `Uploaded ${events.length} event${events.length === 1 ? '' : 's'} to bucket ${config.s3BucketName}`
+                )
+                resolve()
+            })
+        })
+    }
+
+    async copyIntoTableFromStage(batchId: number) {
+        await this.execute({
+            sqlText: `COPY INTO "${this.database}"."${this.dbschema}"."${this.table}"
+            FROM "${this.database}"."${this.dbschema}"."${this.stage}"
+            PATTERN='${batchId}-.*.csv'`,
+        })
+    }
 }
 
 const exportTableColumns = TABLE_SCHEMA.map(({ name, type }) => `"${name.toUpperCase()}" ${type}`).join(', ')
 
-const jsonFields = new Set(TABLE_SCHEMA.filter(({ type }) => type === 'VARIANT').map(({ name }) => name))
-
 const snowflakePlugin: Plugin<SnowflakePluginInput> = {
     async setupPlugin(meta) {
         const { global, config } = meta
+        const { account, username, password, dbschema, table, stage, database } = config
         // Prepare for working with Snowflake
-        global.snowflake = new Snowflake(config.account, config.username, config.password)
-    
+        global.snowflake = new Snowflake({
+            account, 
+            username, 
+            password, 
+            dbschema, 
+            table, 
+            stage, 
+            database 
+        })
+
         // Create table
         await global.snowflake.createTableIfNotExists(
-            config.database,
-            config.dbschema,
-            config.table,
             exportTableColumns
         )
 
         // Create stage
-        await global.snowflake.createStageIfNotExists(
-            config.database,
-            config.dbschema,
-            config.stage,
-        )
-    
-        global.eventsToIgnore = new Set<string>(
-            (config.eventsToIgnore || '').split(',').map((event) => event.trim())
-        )
+        await global.snowflake.createStageIfNotExists()
+
+        global.batchId = Math.round(Math.random()*100000000)
+        global.useS3 = config.stageToUse === 'S3'
+        if (global.useS3) {
+            global.snowflake.createS3Connector(config.awsAccessKeyId, config.awsSecretAccessKey, config.awsRegion, config.s3BucketName)
+        }
+
+        global.eventsToIgnore = new Set<string>((config.eventsToIgnore || '').split(',').map((event) => event.trim()))
     },
 
     async teardownPlugin({ global }) {
         await global.snowflake.clear()
     },
-    
-    async exportEvents (events, { global, config }) {
+
+    async exportEvents(events, meta) {
+        const { global, config } = meta
         const rows = events.filter((event) => !global.eventsToIgnore.has(event.event.trim())).map(transformEventToRow)
         if (rows.length) {
-            console.info(`Saving batch of ${rows.length} event${rows.length !== 1 ? 's' : ''} to Snowflake stage "${config.stage}"`)
+            console.info(
+                `Saving batch of ${rows.length} event${rows.length !== 1 ? 's' : ''} to Snowflake stage "${
+                    config.stage
+                }"`
+            )
         } else {
             console.info(`Skipping an empty batch of events`)
         }
         try {
-            await fetch(`https://${config.host}/e`, {
-                method: 'POST',
-                body: JSON.stringify(events),
-                headers: { 'Content-Type': 'application/json' },
-            })
+            global.snowflake.uploadToS3(rows, meta)
         } catch (error) {
-            throw new RetryError() 
+            throw new RetryError()
         }
     },
+
+    async runEveryMinute({ cache, global }) {
+        const lastRun = await cache.get('lastRun', null)
+        const ONE_HOUR = 60*60*1000
+        const timeNow = new Date().getTime()
+        if (
+            lastRun &&
+            timeNow - Number(lastRun) < ONE_HOUR 
+        ) {
+            return
+        }
+        await cache.set('lastRun', timeNow)
+        if (global.useS3) {
+            global.snowflake.copyIntoTableFromStage(global.batchId)
+        }
+
+    }
 }
 
 export default snowflakePlugin
-
-function getSnowpipeJwt() {
-    const publicKeyBytes = crypto.createPublicKey(pem).export({ type: 'spki', format: 'der'});
-    const signature = 'SHA256:' + crypto.createHash('sha256').update(publicKeyBytes).digest().toString('base64');const bearer = jose.encode({
-        iss: `${account}.${username}.${signature}`,
-        sub: `${account}.${username}`,
-        iat: Math.round(new Date().getTime() / 1000),
-        exp: Math.round(new Date().getTime() / 1000 + 60 * 59)
-      }, pem, 'RS256');
-}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "description": "Export PostHog events into Snowflake",
     "devDependencies": {
         "@posthog/plugin-contrib": "^0.0.5",
-        "@posthog/plugin-scaffold": "^0.11.0",
+        "@posthog/plugin-scaffold": "^0.12.0",
         "@types/generic-pool": "^3.1.9",
         "@types/snowflake-sdk": "^1.5.1",
         "generic-pool": "^3.7.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "description": "Export PostHog events into Snowflake",
     "devDependencies": {
         "@posthog/plugin-contrib": "^0.0.5",
-        "@posthog/plugin-scaffold": "^0.10.0",
+        "@posthog/plugin-scaffold": "^0.11.0",
         "@types/generic-pool": "^3.1.9",
         "@types/snowflake-sdk": "^1.5.1",
         "generic-pool": "^3.7.1",

--- a/package.json
+++ b/package.json
@@ -10,5 +10,10 @@
         "@types/snowflake-sdk": "^1.5.1",
         "generic-pool": "^3.7.1",
         "snowflake-sdk": "^1.6.0"
+    },
+    "dependencies": {
+        "@types/node-fetch": "^2.5.10",
+        "aws-sdk": "^2.939.0",
+        "node-fetch": "^2.6.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,16 +1,14 @@
 {
     "name": "@posthog/snowflake-export-plugin",
     "private": true,
-    "version": "0.0.1",
-    "description": "Export PostHog events into SnowFlake",
+    "version": "0.1.0",
+    "description": "Export PostHog events into Snowflake",
     "devDependencies": {
+        "@posthog/plugin-contrib": "^0.0.5",
+        "@posthog/plugin-scaffold": "^0.10.0",
         "@types/generic-pool": "^3.1.9",
-        "@types/snowflake-sdk": "^1.5.1"
-    },
-    "dependencies": {
-        "@posthog/plugin-contrib": "^0.0.3",
-        "@posthog/plugin-scaffold": "^0.5.0",
-        "generic-pool": "^3.7.8",
+        "@types/snowflake-sdk": "^1.5.1",
+        "generic-pool": "^3.7.1",
         "snowflake-sdk": "^1.6.0"
     }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,9 +1,9 @@
 {
-    "name": "SnowFlake Export Plugin",
+    "name": "Snowflake Export Plugin",
     "url": "https://github.com/posthog/snowflake-export-plugin",
-    "description": "Export PostHog events into SnowFlake",
+    "description": "Export PostHog events into Snowflake",
     "main": "index.ts",
-    "posthogVersion": ">= 1.24.0",
+    "posthogVersion": ">= 1.26.0",
     "config": [
         {
             "key": "account",

--- a/plugin.json
+++ b/plugin.json
@@ -87,7 +87,7 @@
         },
         {
             "key": "purgeFromStage",
-            "name": "Purge events from stage?",
+            "name": "Purge events from stage after copying?",
             "type": "choice",
             "choices": ["No", "Yes"],          
             "default": "No"

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
     "url": "https://github.com/posthog/snowflake-export-plugin",
     "description": "Export PostHog events into Snowflake",
     "main": "index.ts",
-    "posthogVersion": ">= 1.26.0",
+    "posthogVersion": ">=1.25.0",
     "config": [
         {
             "key": "account",
@@ -46,19 +46,18 @@
             "hint": "Will be created if doesn't already exist."
         },
         {
+            "key": "stage",
+            "name": "DB Stage",
+            "type": "string",
+            "required": true,
+            "hint": "Will be created if doesn't already exist."
+        },
+        {
             "key": "eventsToIgnore",
             "name": "Events to ignore",
             "type": "string",
             "default": "$snapshot, $feature_flag_called",
             "hint": "Comma separated list of events to ignore"
         },
-        {
-            "key": "mergeFrequency",
-            "name": "Table Merge Frequency",
-            "type": "choice",
-            "choices": ["hour", "minute"],
-            "default": "hour",
-            "hint": "How often do we merge the temporary tables with the main export table. Once per hour (10 min past the hour) or once per minute (last 2 minutes excluded)"
-        }
     ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -46,6 +46,12 @@
             "hint": "Will be created if doesn't already exist."
         },
         {
+            "key": "role",
+            "name": "Specify a role to access Snowflake with",
+            "type": "string",
+            "hint": "Optional, overrides the default role for the user."
+        },
+        {
             "key": "stageToUse",
             "name": "Stage Type",
             "type": "choice",

--- a/plugin.json
+++ b/plugin.json
@@ -59,5 +59,31 @@
             "default": "$snapshot, $feature_flag_called",
             "hint": "Comma separated list of events to ignore"
         },
+        {
+            "key": "s3BucketName",
+            "name": "S3 Bucket Name",
+            "type": "string"
+        },
+        {
+            "key": "awsAccessKeyId",
+            "name": "AWS Access Key ID",
+            "type": "string"
+        },
+        {
+            "key": "awsSecretAccessKey",
+            "name": "AWS Secret Access Key",
+            "type": "string"
+        },
+        {
+            "key": "awsRegion",
+            "name": "AWS Region",
+            "type": "string"
+        },
+        {
+            "key": "stageToUse",
+            "name": "AWS Region",
+            "type": "choice",
+            "choices": ["S3"]
+        }
     ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -3,11 +3,11 @@
     "url": "https://github.com/posthog/snowflake-export-plugin",
     "description": "Export PostHog events into Snowflake",
     "main": "index.ts",
-    "posthogVersion": ">=1.25.0",
+    "posthogVersion": ">=1.27.0",
     "config": [
         {
             "key": "account",
-            "name": "Account",
+            "name": "Snowflake Account",
             "type": "string",
             "hint": "In the format of \"ab12345\" or \"ab12345.region.cloud\"",
             "required": true
@@ -27,55 +27,57 @@
         },
         {
             "key": "database",
-            "name": "Snowflake database name",
+            "name": "Snowflake Database Name",
             "type": "string",
             "required": true
         },
         {
             "key": "dbschema",
-            "name": "Snowflake database schema",
+            "name": "Snowflake Database Schema Name",
             "type": "string",
             "default": "PUBLIC",
             "required": true
         },
         {
             "key": "table",
-            "name": "Snowflake table name",
+            "name": "Snowflake Table Name",
             "type": "string",
             "required": true,
             "hint": "Will be created if doesn't already exist."
         },
         {
             "key": "warehouse",
-            "name": "Virtual Warehouse to use for copying files",
+            "name": "Snowflake Virtual Warehouse Name",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "hint": "Warehouse to be used for ingesting from stage."
         },
         {
             "key": "role",
-            "name": "Specify a role to access Snowflake with",
+            "name": "Snowflake Role",
             "type": "string",
-            "hint": "Optional, overrides the default role for the user."
+            "hint": "Optional, overrides the default role of the user."
         },
         {
             "key": "stageToUse",
-            "name": "Stage Type",
+            "name": "Object Storage",
             "type": "choice",
-            "choices": ["S3"]
+            "choices": ["S3"],
+            "hint": "Object storage platform that will be used for staging data for Snowflake export."
         },
         {
             "key": "stage",
-            "name": "Name to use for external stage",
+            "name": "Snowflake Stage Name",
             "type": "string",
             "required": true,
-            "hint": "Will be created if doesn't already exist."
+            "hint": "External (object storage) stage where files will be stored before final export."
         },
         {
             "key": "eventsToIgnore",
-            "name": "Events to ignore",
+            "name": "Ignored Events",
             "type": "string",
             "default": "$snapshot, $feature_flag_called",
-            "hint": "Comma separated list of events to ignore"
+            "hint": "Comma-separated list of events to ignore."
         },
         {
             "key": "s3BucketName",
@@ -100,7 +102,7 @@
         },
         {
             "key": "purgeFromStage",
-            "name": "Purge events from stage after copying?",
+            "name": "Purge Events from Object Storage after Copy?",
             "type": "choice",
             "choices": ["No", "Yes"],          
             "default": "No"

--- a/plugin.json
+++ b/plugin.json
@@ -14,40 +14,46 @@
         },
         {
             "key": "username",
-            "name": "Username",
+            "name": "Snowflake Username",
             "type": "string",
             "required": true
         },
         {
             "key": "password",
-            "name": "Password",
+            "name": "Snowflake Password",
             "type": "string",
             "required": false,
             "secret": true
         },
         {
             "key": "database",
-            "name": "Database",
+            "name": "Snowflake database name",
             "type": "string",
             "required": true
         },
         {
             "key": "dbschema",
-            "name": "DB Schema",
+            "name": "Snowflake database schema",
             "type": "string",
             "default": "PUBLIC",
             "required": true
         },
         {
             "key": "table",
-            "name": "DB Table",
+            "name": "Snowflake table name",
             "type": "string",
             "required": true,
             "hint": "Will be created if doesn't already exist."
         },
         {
+            "key": "stageToUse",
+            "name": "Stage Type",
+            "type": "choice",
+            "choices": ["S3"]
+        },
+        {
             "key": "stage",
-            "name": "DB Stage",
+            "name": "Name to use for external stage",
             "type": "string",
             "required": true,
             "hint": "Will be created if doesn't already exist."
@@ -80,10 +86,11 @@
             "type": "string"
         },
         {
-            "key": "stageToUse",
-            "name": "Stage Type",
+            "key": "purgeFromStage",
+            "name": "Purge events from stage?",
             "type": "choice",
-            "choices": ["S3"]
+            "choices": ["No", "Yes"],          
+            "default": "No"
         }
     ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -46,6 +46,12 @@
             "hint": "Will be created if doesn't already exist."
         },
         {
+            "key": "warehouse",
+            "name": "Virtual Warehouse to use for copying files",
+            "required": true,
+            "type": "string"
+        },
+        {
             "key": "role",
             "name": "Specify a role to access Snowflake with",
             "type": "string",
@@ -84,7 +90,8 @@
         {
             "key": "awsSecretAccessKey",
             "name": "AWS Secret Access Key",
-            "type": "string"
+            "type": "string",
+            "secret": true
         },
         {
             "key": "awsRegion",

--- a/plugin.json
+++ b/plugin.json
@@ -81,7 +81,7 @@
         },
         {
             "key": "stageToUse",
-            "name": "AWS Region",
+            "name": "Stage Type",
             "type": "choice",
             "choices": ["S3"]
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,27 +11,15 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@maxmind/geoip2-node@^2.3.1":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@maxmind/geoip2-node/-/geoip2-node-2.3.2.tgz#a0aaf8452693491e815021fe16e692959490ba6d"
-  integrity sha512-a1TSZt3uWe7yrgE2WMdTItK6XuG2Aj125cAXA+JuT2nomv3oqIK8XXg9iJVpzNXAYRV72XO0+zY+3HluOGgF3w==
-  dependencies:
-    camelcase-keys "^6.0.1"
-    ip6addr "^0.2.3"
-    lodash.set "^4.3.2"
-    maxmind "^4.2.0"
+"@posthog/plugin-contrib@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-contrib/-/plugin-contrib-0.0.5.tgz#6c55f39c39dd9dd8af558888558a69bc3fe19aff"
+  integrity sha512-ic2JsfFUdLGF+fGYJPatWEB6gEFNoD89qz92FN1RE2QfLpr6YdyPNuMowzahya3hfC/jaLZ8QdPG/j5pSOgT7A==
 
-"@posthog/plugin-contrib@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-contrib/-/plugin-contrib-0.0.3.tgz#d0772c6dd9ec9944ebee9dc475e1e781256b0b5f"
-  integrity sha512-0HrE8AuPv3OLZA93RrJDbljn9u5D/wmiIkBCeckU3LL67LNozDIJgKsY4Td91zgc+b4Rlx/X0MJNp2l6BHbQqg==
-
-"@posthog/plugin-scaffold@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.5.0.tgz#0d46d0f39700ebf3cf613ba80a2c9a4dc6d13805"
-  integrity sha512-gE12hy/gYdMOYLP/PhbC2XfqvCeoXrdkFeR9HFfSK31RWU+aW+JMK7pi+CATatXfNpMCvjGxIYJk3QBPwm0WDA==
-  dependencies:
-    "@maxmind/geoip2-node" "^2.3.1"
+"@posthog/plugin-scaffold@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.10.0.tgz#e80f57c5d3833753632607bed3ca71ebf272b12b"
+  integrity sha512-c8lNzQTBMJ0X3SCjcaD+mXZIx2thc+ptf8G4gbfT9YBFFD6TMaxs+/APMUab2aRJRbVwOsCGj9poxwuF4wxPpA==
 
 "@types/generic-pool@^3.1.9":
   version "3.1.9"
@@ -199,20 +187,6 @@ buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
   integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
-
-camelcase-keys@^6.0.1:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
-  integrity sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==
-  dependencies:
-    camelcase "^5.3.1"
-    map-obj "^4.0.0"
-    quick-lru "^4.0.1"
-
-camelcase@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
-  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -387,7 +361,7 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-generic-pool@^3.7.8:
+generic-pool@^3.7.1:
   version "3.7.8"
   resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.7.8.tgz#202087bf5ec5e0b3bae39842a0ef98bcd4c1e450"
   integrity sha512-Pz93INFSbhjEROVbM91rurD05G+Kx8833rG+lVU57mznEBpzkc1f5/g+d511a1Yf8dbAEsm7DDA3QLytMFbiGA==
@@ -438,14 +412,6 @@ inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-ip6addr@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/ip6addr/-/ip6addr-0.2.3.tgz#660df0d27092434f0aadee025aba8337c6d7d4d4"
-  integrity sha512-qA9DXRAUW+lT47/i/4+Q3GHPwZjGt/atby1FH/THN6GVATA6+Pjp2nztH7k6iKeil7hzYnBwfSsxjthlJ8lJKw==
-  dependencies:
-    assert-plus "^1.0.0"
-    jsprim "^1.4.0"
 
 is-arrayish@^0.3.1:
   version "0.3.2"
@@ -520,7 +486,7 @@ jsonwebtoken@^8.5.1:
     ms "^2.1.1"
     semver "^5.6.0"
 
-jsprim@^1.2.2, jsprim@^1.4.0:
+jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
   integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
@@ -587,11 +553,6 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
-
 lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
@@ -607,19 +568,6 @@ logform@^2.2.0:
     fecha "^4.2.0"
     ms "^2.1.1"
     triple-beam "^1.3.0"
-
-map-obj@^4.0.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.2.1.tgz#e4ea399dbc979ae735c83c863dd31bdf364277b7"
-  integrity sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==
-
-maxmind@^4.2.0:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/maxmind/-/maxmind-4.3.1.tgz#b20103f19e9fc12e4d1618814380d89a00f65770"
-  integrity sha512-0CxAgwWIwQy4zF1/qCMOeUPleMTYgfnsuIsZ4Otzx6hzON4PCqivPiH6Kz7iWrC++KOGCbSB3nxkJMvDEdWt6g==
-  dependencies:
-    mmdb-lib "1.2.0"
-    tiny-lru "7.0.6"
 
 mime-db@1.46.0:
   version "1.46.0"
@@ -642,11 +590,6 @@ mkdirp@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
-mmdb-lib@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mmdb-lib/-/mmdb-lib-1.2.0.tgz#0ecd93f4942f65a2d09be0502fa9126939606727"
-  integrity sha512-3XYebkStxqCgWJjsmT9FCaE19Yi4Tvs2SBPKhUks3rJJh52oF1AKAd9kei+LTutud3a6RCZ0o2Um96Fn7o3zVA==
 
 mock-require@^3.0.3:
   version "3.0.3"
@@ -735,11 +678,6 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-
-quick-lru@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
-  integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
 readable-stream@^2.3.7:
   version "2.3.7"
@@ -840,7 +778,7 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
-snowflake-sdk@^1.6.1:
+snowflake-sdk@^1.6.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/snowflake-sdk/-/snowflake-sdk-1.6.1.tgz#371a19bc04922c437ef72b62f1a59b5c5999d577"
   integrity sha512-w56tIP8mXyD2pXFzeV78sQjiBZBdPshKII2K/9E6Wo++eM+JMcY2qszq3jIjyIsXSWKDcUlKUR2ENcG7WDWeUQ==
@@ -907,11 +845,6 @@ text-hex@1.0.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
   integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
-
-tiny-lru@7.0.6:
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/tiny-lru/-/tiny-lru-7.0.6.tgz#b0c3cdede1e5882aa2d1ae21cb2ceccf2a331f24"
-  integrity sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==
 
 tough-cookie@~2.5.0:
   version "2.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,10 +16,10 @@
   resolved "https://registry.yarnpkg.com/@posthog/plugin-contrib/-/plugin-contrib-0.0.5.tgz#6c55f39c39dd9dd8af558888558a69bc3fe19aff"
   integrity sha512-ic2JsfFUdLGF+fGYJPatWEB6gEFNoD89qz92FN1RE2QfLpr6YdyPNuMowzahya3hfC/jaLZ8QdPG/j5pSOgT7A==
 
-"@posthog/plugin-scaffold@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.10.0.tgz#e80f57c5d3833753632607bed3ca71ebf272b12b"
-  integrity sha512-c8lNzQTBMJ0X3SCjcaD+mXZIx2thc+ptf8G4gbfT9YBFFD6TMaxs+/APMUab2aRJRbVwOsCGj9poxwuF4wxPpA==
+"@posthog/plugin-scaffold@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.11.0.tgz#2c94621a98ce5162d5576737e3caf66b1c94941f"
+  integrity sha512-ZqI9yBe9hSswf6lDf2Ydl/hRk0WFd4ARluu3pOwkkPOwCfnPhkbPR6729inCPvuw2yoKV/IWOOg/yyd70Nh3AQ==
 
 "@types/generic-pool@^3.1.9":
   version "3.1.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,6 +28,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/node-fetch@^2.5.10":
+  version "2.5.10"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.10.tgz#9b4d4a0425562f9fcea70b12cb3fcdd946ca8132"
+  integrity sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "14.14.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.6.tgz#146d3da57b3c636cc0d1769396ce1cfa8991147f"
@@ -139,6 +147,21 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+aws-sdk@^2.939.0:
+  version "2.939.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.939.0.tgz#c07c9d726bcb2ffdb69016f880ae310ad72f36a5"
+  integrity sha512-2KEAtTlVMDcpHP6+P9JU+mXTNhX3KZ0StW0Qi87oh8EUoRITZj64FrUylNvrCg69thCliAcNzBdlA1g5Iq+qEA==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -155,6 +178,11 @@ axios@^0.21.1:
   integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
     follow-redirects "^1.10.0"
+
+base64-js@^1.0.2:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
@@ -187,6 +215,15 @@ buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
   integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
+
+buffer@4.9.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -239,7 +276,7 @@ colorspace@1.1.x:
     color "3.0.x"
     text-hex "1.0.x"
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -302,6 +339,11 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 extend@^3.0.2, extend@~3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
@@ -351,6 +393,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -408,6 +459,16 @@ https-proxy-agent@^3.0.0:
     agent-base "^4.3.0"
     debug "^3.1.0"
 
+ieee754@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
+ieee754@^1.1.4:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
@@ -440,7 +501,7 @@ is-wsl@^2.1.1:
   dependencies:
     is-docker "^2.0.0"
 
-isarray@~1.0.0:
+isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -449,6 +510,11 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
+
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -616,6 +682,11 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
@@ -669,6 +740,11 @@ psl@^1.1.28:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -678,6 +754,11 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 readable-stream@^2.3.7:
   version "2.3.7"
@@ -755,6 +836,16 @@ safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 semver@^5.6.0:
   version "5.7.1"
@@ -878,10 +969,23 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 uuid@^3.3.2:
   version "3.4.0"
@@ -924,3 +1028,16 @@ winston@^3.1.0:
     stack-trace "0.0.x"
     triple-beam "^1.3.0"
     winston-transport "^4.4.0"
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,10 +16,10 @@
   resolved "https://registry.yarnpkg.com/@posthog/plugin-contrib/-/plugin-contrib-0.0.5.tgz#6c55f39c39dd9dd8af558888558a69bc3fe19aff"
   integrity sha512-ic2JsfFUdLGF+fGYJPatWEB6gEFNoD89qz92FN1RE2QfLpr6YdyPNuMowzahya3hfC/jaLZ8QdPG/j5pSOgT7A==
 
-"@posthog/plugin-scaffold@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.11.0.tgz#2c94621a98ce5162d5576737e3caf66b1c94941f"
-  integrity sha512-ZqI9yBe9hSswf6lDf2Ydl/hRk0WFd4ARluu3pOwkkPOwCfnPhkbPR6729inCPvuw2yoKV/IWOOg/yyd70Nh3AQ==
+"@posthog/plugin-scaffold@^0.12.0":
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.12.5.tgz#596539ea69df21f07640a2ce0a335c7ead940b06"
+  integrity sha512-EuRoYM17vYI1m2SmXpYe7LC9hFPWsRnN6rAi6q3unFIW26pT40sV/TYSWnBEihZXIWdVShwiGXORQMHjpnJOig==
 
 "@types/generic-pool@^3.1.9":
   version "3.1.9"


### PR DESCRIPTION
I originally forked #4 but turns out there wasn't too much to reuse from there.

Will add GCS in another PR.

## How this works

- `exportEvents` function sends the events to S3. This is done in CSV format, because Snowflake does not support multi-column JSON copies. As this is in `exportEvents`, anything that fails here will be retried according to our exponential backoff mechanism.
- `runEveryMinute` is used to actually run every _hour_. This approach is used in other plugins to give immediate feedback on installation. This will issue a `COPY INTO` statement to Snowflake to copy the relevant files from S3. The user can choose if they want to purge these from the stage on copy or not.
- The above will also be retried with exponential backoff, so that we try up to 15 times to send to S3, and yet another 15 to send to Snowflake. This makes sure users get their events for sure, even if services along the way are down for a good amount of time.