### PR TITLE
Don't error out when bucket path doesn't exist

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -514,11 +514,11 @@ const snowflakePlugin: Plugin<SnowflakePluginInput> = {
             bucketPath = `${config.bucketPath}/`
         }
 
-        if (bucketPath.startsWith('/')) {
+        if (bucketPath && bucketPath.startsWith('/')) {
             bucketPath = bucketPath.slice(1)
         }
 
-        global.parsedBucketPath = bucketPath
+        global.parsedBucketPath = bucketPath || ''
     },
 
     async teardownPlugin(meta) {


### PR DESCRIPTION
Leads to error like: https://posthogusers.slack.com/archives/C01FKPGG5U6/p1630509438020300?thread_ts=1627566038.204900&cid=C01FKPGG5U6