### PR TITLE
fix: Actually skip writing to storage if no events

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -577,6 +577,7 @@ const snowflakePlugin: Plugin<SnowflakePluginInput> = {
             )
         } else {
             console.info(`Skipping an empty batch of events`)
+            return
         }
         try {
             if (global.useS3) {


### PR DESCRIPTION
Otherwise we'd create empty files and then try to copy them to snowflake, which is all a waste of resources if nothing else.