### PR TITLE
copy into in  smaller batches via jobs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -449,6 +449,8 @@ class Snowflake {
         await this.execute({
             sqlText: querySqlText,
         })
+
+        console.log('COPY INTO ran successfully')
     }
 }
 
@@ -624,27 +626,13 @@ async function copyIntoSnowflake({ cache, storage, global, jobs }: Meta<Snowflak
     }
     await cache.set('lastRun', timeNow)
     console.log(`Copying ${String(filesStagedForCopy)} from object storage into Snowflake`)
-    // Snowflake's COPY INTO only supports up to 1000 files at a time, so we split into multiple COPY INTO statements of size 999
-    const chunkSize = 999
+
+    const chunkSize = 50
     for (let i = 0; i < filesStagedForCopy.length; i += chunkSize) {
         const chunkStagedForCopy = filesStagedForCopy.slice(i, i + chunkSize)
-        
-        try {
-            await global.snowflake.copyIntoTableFromStage(
-                chunkStagedForCopy,
-                global.purgeEventsFromStage,
-                global.forceCopy,
-                global.debug
-            )
-            console.log('COPY INTO ran successfully')
-        } catch {
-            await jobs
-                .retryCopyIntoSnowflake({ retriesPerformedSoFar: 0, filesStagedForCopy: chunkStagedForCopy })
-                .runIn(3, 'seconds')
-            console.error(
-                `Failed to copy ${String(filesStagedForCopy)} from object storage into Snowflake. Retrying in 3s.`
-            )
-        }
+        await jobs
+            .retryCopyIntoSnowflake({ retriesPerformedSoFar: 0, filesStagedForCopy: chunkStagedForCopy })
+            .runIn(3, 'seconds')
     }
     await storage.del(FILES_STAGED_KEY)
 }


### PR DESCRIPTION
I noticed we were having some errors with `query canceled` - and I suspect that with the large batches we're actually timing out. Let's try smaller batches instead, each in a job of its own, rather than trying to do all of them in the same 30s execution window.
