### PR TITLE
Make cadence of copy into Snowflake configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Export events to a Snowflake table regularly.
 
 ## What This Does
 
-This plugin uses a Snowflake external stage to stage events in object storage - Amazon S3 or Google Cloud Storage. Staged events (stored in object storage as files containing event batches) are then copied into the final destination – your Snowflake table – once an hour.
+This plugin uses a Snowflake external stage to stage events in object storage - Amazon S3 or Google Cloud Storage. Staged events (stored in object storage as files containing event batches) are then copied into the final destination – your Snowflake table – once every 10 minutes (or a cadence of your choosing).
 
 Prerequisites:
 

--- a/index.ts
+++ b/index.ts
@@ -618,9 +618,9 @@ async function copyIntoSnowflake({ cache, storage, global, jobs, config }: Meta<
     }
     const lastRun = await cache.get('lastRun', null)
     const copyCadenceMinutes = parseInt(config.copyCadenceMinutes) || 10
-    const MAX_TIME = copyCadenceMinutes * 60 * 1000
+    const maxTime = copyCadenceMinutes * 60 * 1000
     const timeNow = new Date().getTime()
-    if (!force && lastRun && timeNow - Number(lastRun) < MAX_TIME) {
+    if (!force && lastRun && timeNow - Number(lastRun) < maxTime) {
         if (global.debug) {
             console.log('Skipping COPY INTO', timeNow, lastRun)
         }

--- a/index.ts
+++ b/index.ts
@@ -39,6 +39,7 @@ interface SnowflakePluginInput {
         retryCopyIntoOperations: 'Yes' | 'No'
         forceCopy: 'Yes' | 'No'
         debug: 'ON' | 'OFF'
+        copyCadenceMinutes: string
     }
     cache: CacheExtension
     storage: StorageExtension
@@ -599,7 +600,7 @@ const snowflakePlugin: Plugin<SnowflakePluginInput> = {
     },
 }
 
-async function copyIntoSnowflake({ cache, storage, global, jobs }: Meta<SnowflakePluginInput>, force = false) {
+async function copyIntoSnowflake({ cache, storage, global, jobs, config }: Meta<SnowflakePluginInput>, force = false) {
     if (global.debug) {
         console.info('Running copyIntoSnowflake')
     }
@@ -616,7 +617,8 @@ async function copyIntoSnowflake({ cache, storage, global, jobs }: Meta<Snowflak
         console.log('Files staged for copy:', filesStagedForCopy)
     }
     const lastRun = await cache.get('lastRun', null)
-    const MAX_TIME = 10 * 60 * 1000 // 10 min
+    const copyCadenceMinutes = parseInt(config.copyCadenceMinutes) || 10
+    const MAX_TIME = copyCadenceMinutes * 60 * 1000
     const timeNow = new Date().getTime()
     if (!force && lastRun && timeNow - Number(lastRun) < MAX_TIME) {
         if (global.debug) {

--- a/plugin.json
+++ b/plugin.json
@@ -58,6 +58,12 @@
             "hint": "Optional, overrides the default role for the user."
         },
         {
+            "key": "copyCadenceMinutes",
+            "name": "How often (in minutes) data should be copied into Snowflake",
+            "type": "string",
+            "default": "10"
+        },
+        {
             "key": "stageToUse",
             "name": "Stage type",
             "type": "choice",


### PR DESCRIPTION
Fixes #27.

This PR adds a new `copyCadenceMinutes` configuration field, allowing users to specify a custom cadence for copying data into Snowflake instead of the default of 10 minutes.