### PR TITLE
Add a dash of retry and wait for connecting to snowflake cluster

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -62,7 +62,7 @@ async function retryPromiseWithDelay(promise, nthTry, delayTime) {
     const res = await promise;
     return res;
   } catch (e) {
-    if (nthTry === 1) {
+    if (nthTry <= 1) {
       return Promise.reject(e);
     }
     console.log('retrying', nthTry, 'time');

--- a/index.ts
+++ b/index.ts
@@ -364,7 +364,7 @@ class Snowflake {
                                 resolve(conn.getId())
                             }
                         })
-                    ), 5, 5)
+                    ), 5, 5000)
 
                     return connection
                 },

--- a/index.ts
+++ b/index.ts
@@ -46,6 +46,32 @@ interface SnowflakePluginInput {
     storage: StorageExtension
 }
 
+/**
+ * Util function to return a promise which is resolved in provided milliseconds
+ */
+function waitFor(millSeconds) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve();
+    }, millSeconds);
+  });
+}
+
+async function retryPromiseWithDelay(promise, nthTry, delayTime) {
+  try {
+    const res = await promise;
+    return res;
+  } catch (e) {
+    if (nthTry === 1) {
+      return Promise.reject(e);
+    }
+    console.log('retrying', nthTry, 'time');
+    // wait for delayTime amount of time before calling this method again
+    await waitFor(delayTime);
+    return retryPromiseWithDelay(promise, nthTry - 1, delayTime);
+  }
+}
+
 interface TableRow {
     uuid: string
     event: string
@@ -329,7 +355,7 @@ class Snowflake {
                         ...roleConfig,
                     })
 
-                    await new Promise<string>((resolve, reject) =>
+                    await retryPromiseWithDelay(new Promise<string>((resolve, reject) =>
                         connection.connect((err, conn) => {
                             if (err) {
                                 console.error('Error connecting to Snowflake: ' + err.message)
@@ -338,7 +364,7 @@ class Snowflake {
                                 resolve(conn.getId())
                             }
                         })
-                    )
+                    ), 5, 5)
 
                     return connection
                 },


### PR DESCRIPTION
This is somewhat inspired from the thread here: 
https://github.com/snowflakedb/snowflake-connector-nodejs/issues/349#issuecomment-1302331817

But in general we should retry with some wait in between while connecting to the Snowflake warehouse.

I'm going to test this tomorrow on my test cluster for this.